### PR TITLE
Redact database and collection names (`--redactNamespaces`, default: `false`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ download the latest stable release for your OS and architecture (e.g., `anonymon
 
 Here's the full list of the latest stable (0.3.x) binaries for your convenience:
 
-- [macOS M-type chip](https://github.com/yuvalherziger/anonymongo/releases/download/1.0.3/anonymongo_Darwin_arm64.tar.gz)
-- [macOS Intel chip](https://github.com/yuvalherziger/anonymongo/releases/download/1.0.3/anonymongo_Darwin_x86_64.tar.gz)
-- [Windows x86_64](https://github.com/yuvalherziger/anonymongo/releases/download/1.0.3/anonymongo_Windows_x86_64.zip)
-- [Windows arm64](https://github.com/yuvalherziger/anonymongo/releases/download/1.0.3/anonymongo_Windows_arm64.zip)
-- [Linux arm64](https://github.com/yuvalherziger/anonymongo/releases/download/1.0.3/anonymongo_Linux_arm64.tar.gz)
-- [Linux x86_64](https://github.com/yuvalherziger/anonymongo/releases/download/1.0.3/anonymongo_Linux_x86_64.tar.gz)
+- [macOS M-type chip](https://github.com/yuvalherziger/anonymongo/releases/download/1.1.0/anonymongo_Darwin_arm64.tar.gz)
+- [macOS Intel chip](https://github.com/yuvalherziger/anonymongo/releases/download/1.1.0/anonymongo_Darwin_x86_64.tar.gz)
+- [Windows x86_64](https://github.com/yuvalherziger/anonymongo/releases/download/1.1.0/anonymongo_Windows_x86_64.zip)
+- [Windows arm64](https://github.com/yuvalherziger/anonymongo/releases/download/1.1.0/anonymongo_Windows_arm64.zip)
+- [Linux arm64](https://github.com/yuvalherziger/anonymongo/releases/download/1.1.0/anonymongo_Linux_arm64.tar.gz)
+- [Linux x86_64](https://github.com/yuvalherziger/anonymongo/releases/download/1.1.0/anonymongo_Linux_x86_64.tar.gz)
 
 Extract the downloaded archive and run the `anonymongo` binary. Depending on the OS settings, you may be prompted to trust the program explicitly.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Main features:
       - [2.1.7.1 `--replacement <STRING>`](#2171---replacement-string)
       - [2.1.7.2 `--redactBooleans`](#2172---redactbooleans)
       - [2.1.7.3 `--redactNumbers`](#2173---redactnumbers)
+      - [2.1.7.4 `--redactNamspaces`](#2174---redactnamespaces)
   - [2.2 The `anonymongo decrypt` Command](#22-the-anonymongo-decrypt-command)
 - [3. Using Docker](#3-using-docker)
 - [4. Tests](#4-tests)
@@ -286,6 +287,12 @@ The `--redactBooleans` flag (default: `false`) redacts all boolean values to a c
 ##### 2.1.7.3 `--redactNumbers`
 
 The `--redactNumbers` flag (default: `false`) redacts all boolean values to a constant `0` value.
+
+---
+
+##### 2.1.7.4 `--redactNamespaces`
+
+The `--redactNamespaces` flag (default: `false`) hashes database and collection names in the log file.
 
 ---
 

--- a/src/anonymizer.go
+++ b/src/anonymizer.go
@@ -83,6 +83,9 @@ func RedactMongoLog(jsonStr string) (*orderedmap.OrderedMap[string, any], error)
 		if cmdOk {
 			if cmdMap, ok := cmd.(*orderedmap.OrderedMap[string, any]); ok {
 				redactCommand(cmdMap, shouldEagerRedact)
+				if redactNamespaces {
+					redactNamespace(cmdMap)
+				}
 				attr.Set("cmd", cmdMap)
 			}
 		}

--- a/src/anonymizer.go
+++ b/src/anonymizer.go
@@ -115,7 +115,7 @@ func RedactMongoLog(jsonStr string) (*orderedmap.OrderedMap[string, any], error)
 }
 
 func redactNamespace(cmd *orderedmap.OrderedMap[string, any]) {
-	searchedFields := []string{"ns", "aggregate", "insert", "find", "update", "collection", "delete", "$db"}
+	searchedFields := []string{"ns", "aggregate", "insert", "find", "update", "collection", "delete", "$db", "count", "findAndModify", "findOneAndDelete", "replace", "findOneAndReplace", "findOneAndUpdate", "getIndexes", "countDocuments"}
 	for _, field := range searchedFields {
 		if value, ok := cmd.Get(field); ok {
 			if valueStr, ok := value.(string); ok {

--- a/src/anonymizer.go
+++ b/src/anonymizer.go
@@ -17,6 +17,7 @@ var (
 	RedactedFieldMapping = map[string]string{}
 	shouldEncrypt        = false
 	encryptionKey        []byte
+	redactNamespaces     = false
 )
 
 func SetRedactedString(s string)            { redactedString = s }
@@ -26,6 +27,7 @@ func SetRedactIPs(b bool)                   { redactIPs = b }
 func SetEagerRedactionPaths(paths []string) { eagerRedactionPaths = paths }
 func SetEncryptionKey(key []byte)           { encryptionKey = key }
 func SetShouldEncrypt(b bool)               { shouldEncrypt = b }
+func SetRedactNamespaces(b bool)            { redactNamespaces = b }
 
 func RedactMongoLog(jsonStr string) (*orderedmap.OrderedMap[string, any], error) {
 	// entry := orderedmap.NewOrderedMap[string, any]()
@@ -72,6 +74,9 @@ func RedactMongoLog(jsonStr string) (*orderedmap.OrderedMap[string, any], error)
 		if ocOk {
 			if ocMap, ok := originatingCommand.(*orderedmap.OrderedMap[string, any]); ok {
 				redactCommand(ocMap, shouldEagerRedact)
+				if redactNamespaces {
+					redactNamespace(ocMap)
+				}
 				attr.Set("originatingCommand", ocMap)
 			}
 		}
@@ -81,6 +86,9 @@ func RedactMongoLog(jsonStr string) (*orderedmap.OrderedMap[string, any], error)
 		}
 		if cmdMap, ok := command.(*orderedmap.OrderedMap[string, any]); ok {
 			redactCommand(cmdMap, shouldEagerRedact)
+			if redactNamespaces {
+				redactNamespace(cmdMap)
+			}
 			attr.Set("command", cmdMap)
 		}
 		if shouldEagerRedact {
@@ -92,7 +100,30 @@ func RedactMongoLog(jsonStr string) (*orderedmap.OrderedMap[string, any], error)
 			}
 		}
 	}
+
+	if redactNamespaces {
+		ns, ok := attr.Get("ns")
+		if ok {
+			if nsStr, ok := ns.(string); ok {
+				redactedNs := HashName(nsStr)
+				attr.Set("ns", redactedNs)
+			}
+		}
+	}
+
 	return entry, nil
+}
+
+func redactNamespace(cmd *orderedmap.OrderedMap[string, any]) {
+	searchedFields := []string{"ns", "aggregate", "insert", "find", "update", "collection", "delete", "$db"}
+	for _, field := range searchedFields {
+		if value, ok := cmd.Get(field); ok {
+			if valueStr, ok := value.(string); ok {
+				redactedValue := HashName(valueStr)
+				cmd.Set(field, redactedValue)
+			}
+		}
+	}
 }
 
 func redactCommand(cmd *orderedmap.OrderedMap[string, any], shouldEagerRedact bool) {
@@ -160,7 +191,7 @@ func redactFieldNamesFromPlanSummary(planSummary string) string {
 	result := planSummary
 	fieldNames := ParsePlanSummary(planSummary)
 	for _, fieldName := range fieldNames {
-		hashed := HashFieldName(fieldName)
+		hashed := HashName(fieldName)
 		result = strings.ReplaceAll(result, fieldName, hashed)
 	}
 	return result
@@ -243,7 +274,7 @@ func redactPipelineStage(stage interface{}, redactFieldNames bool, keyPath []str
 			newKeyPath := append(keyPath, k)
 			opMeta, isOp := getOp(newKeyPath, inSearchStage)
 			if redactFieldNames && (!isOp || (isOp && opMeta == nil)) {
-				redactedKey = HashFieldName(k)
+				redactedKey = HashName(k)
 			}
 			switch meta := opMeta.(type) {
 			case OperatorType:
@@ -257,7 +288,7 @@ func redactPipelineStage(stage interface{}, redactFieldNames bool, keyPath []str
 							} else if _, isOp := getOp([]string{vTyped}, inSearchStage); isOp {
 								newMap.Set(redactedKey, vTyped)
 							} else {
-								newMap.Set(redactedKey, HashFieldName(vTyped))
+								newMap.Set(redactedKey, HashName(vTyped))
 							}
 						case *orderedmap.OrderedMap[string, any]:
 							newMap.Set(redactedKey, redactPipelineStage(vTyped, redactFieldNames, newKeyPath, inSearchStage))
@@ -265,6 +296,18 @@ func redactPipelineStage(stage interface{}, redactFieldNames bool, keyPath []str
 							newMap.Set(redactedKey, redactArrayValues(vTyped, redactFieldNames, inSearchStage))
 						default:
 							newMap.Set(redactedKey, redactScalarValue([]string{k}, v, inSearchStage))
+						}
+					} else {
+						newMap.Set(redactedKey, v)
+					}
+					continue
+				case Namespace:
+					if redactNamespaces {
+						switch vTyped := v.(type) {
+						case string:
+							newMap.Set(redactedKey, HashName(vTyped))
+						default:
+							newMap.Set(redactedKey, v)
 						}
 					} else {
 						newMap.Set(redactedKey, v)
@@ -310,7 +353,7 @@ func redactPipelineStage(stage interface{}, redactFieldNames bool, keyPath []str
 											if _, isOp := getOp([]string{subVTyped}, inSearchStage); isOp {
 												newSubMap.Set(subK, subVTyped)
 											} else {
-												newSubMap.Set(subK, HashFieldName(subVTyped))
+												newSubMap.Set(subK, HashName(subVTyped))
 											}
 										case *orderedmap.OrderedMap[string, any]:
 											newSubMap.Set(subK, redactPipelineStage(subVTyped, redactFieldNames, append(newKeyPath, subK), inSearchStage))
@@ -318,6 +361,18 @@ func redactPipelineStage(stage interface{}, redactFieldNames bool, keyPath []str
 											newSubMap.Set(subK, redactArrayValues(subVTyped, redactFieldNames, inSearchStage))
 										default:
 											newSubMap.Set(subK, redactScalarValue([]string{k}, subV, inSearchStage))
+										}
+									} else {
+										newSubMap.Set(subK, subV)
+									}
+									continue
+								case Namespace:
+									if redactNamespaces {
+										switch subVTyped := subV.(type) {
+										case string:
+											newSubMap.Set(subK, HashName(subVTyped))
+										default:
+											newSubMap.Set(subK, subV)
 										}
 									} else {
 										newSubMap.Set(subK, subV)
@@ -351,7 +406,7 @@ func redactPipelineStage(stage interface{}, redactFieldNames bool, keyPath []str
 						redactedSubK := subK
 						metaVal, metaOk := meta.Get(subK)
 						if redactFieldNames && (!subFound || (subFound && metaVal == nil && metaOk)) {
-							redactedSubK = HashFieldName(subK)
+							redactedSubK = HashName(subK)
 						}
 						switch subVTyped := subV.(type) {
 						case *orderedmap.OrderedMap[string, any]:
@@ -406,7 +461,7 @@ func redactQueryValues(obj *orderedmap.OrderedMap[string, any], redactFieldNames
 		}
 		if redactFieldNames {
 			if !isOp {
-				redactedKey = HashFieldName(k)
+				redactedKey = HashName(k)
 			}
 		}
 		switch val := v.(type) {
@@ -422,7 +477,7 @@ func redactQueryValues(obj *orderedmap.OrderedMap[string, any], redactFieldNames
 						isOp = true
 					}
 					if redactFieldNames && !isOp {
-						newObj.Set(redactedKey, HashFieldName(str))
+						newObj.Set(redactedKey, HashName(str))
 					} else {
 						newObj.Set(redactedKey, v)
 					}
@@ -454,7 +509,7 @@ func redactArrayValuesWithKey(parentKey string, arr []any, redactFieldNames bool
 						isOp = true
 					}
 					if redactFieldNames && !isOp {
-						arr[i] = HashFieldName(str)
+						arr[i] = HashName(str)
 					} else {
 						arr[i] = item
 					}

--- a/src/anonymizer_test_params.go
+++ b/src/anonymizer_test_params.go
@@ -86,8 +86,8 @@ func AnonymizerTestParams() []RedactTestCase {
 			InputFile: "updateOne.json",
 			Options:   setOptionsRedactedStringsWithEagerRedaction,
 			ExpectedPaths: map[string]interface{}{
-				fmt.Sprintf("command.q.%s.$in.0", HashFieldName("_id")): "REDACTED",
-				fmt.Sprintf("command.u.$set.%s", HashFieldName("bar")):  "REDACTED",
+				fmt.Sprintf("command.q.%s.$in.0", HashName("_id")): "REDACTED",
+				fmt.Sprintf("command.u.$set.%s", HashName("bar")):  "REDACTED",
 			},
 		},
 		{
@@ -181,10 +181,10 @@ func AnonymizerTestParams() []RedactTestCase {
 			InputFile: "simple_find.json",
 			Options:   setOptionsRedactedStringsWithEagerRedaction,
 			ExpectedPaths: map[string]interface{}{
-				"command.filter.foo": nil,
-				"command.filter.bar": nil,
-				fmt.Sprintf("command.filter.%s", HashFieldName("foo")): "REDACTED",
-				fmt.Sprintf("command.filter.%s", HashFieldName("bar")): "REDACTED",
+				"command.filter.foo":                              nil,
+				"command.filter.bar":                              nil,
+				fmt.Sprintf("command.filter.%s", HashName("foo")): "REDACTED",
+				fmt.Sprintf("command.filter.%s", HashName("bar")): "REDACTED",
 			},
 		},
 		{
@@ -192,10 +192,10 @@ func AnonymizerTestParams() []RedactTestCase {
 			InputFile: "simple_aggregation.json",
 			Options:   setOptionsRedactedStringsWithEagerRedaction,
 			ExpectedPaths: map[string]interface{}{
-				"command.pipeline.0.$match.status":                                                nil,
-				"command.pipeline.0.$match.createdAt.$lt.$date":                                   nil,
-				fmt.Sprintf("command.pipeline.0.$match.%s", HashFieldName("status")):              "REDACTED",
-				fmt.Sprintf("command.pipeline.0.$match.%s.$lt.$date", HashFieldName("createdAt")): "1970-01-01T00:00:00.000Z",
+				"command.pipeline.0.$match.status":                                           nil,
+				"command.pipeline.0.$match.createdAt.$lt.$date":                              nil,
+				fmt.Sprintf("command.pipeline.0.$match.%s", HashName("status")):              "REDACTED",
+				fmt.Sprintf("command.pipeline.0.$match.%s.$lt.$date", HashName("createdAt")): "1970-01-01T00:00:00.000Z",
 			},
 		},
 		{
@@ -203,14 +203,14 @@ func AnonymizerTestParams() []RedactTestCase {
 			InputFile: "find_with_expr.json",
 			Options:   setOptionsRedactedStringsWithEagerRedaction,
 			ExpectedPaths: map[string]interface{}{
-				"command.filter.$expr.$and.0.$eq.0":                  HashFieldName("foo"),
-				"command.filter.$expr.$and.0.$eq.1":                  "REDACTED",
-				"command.filter.$expr.$and.1.$eq.0":                  HashFieldName("bar"),
-				"command.filter.$expr.$and.1.$eq.1":                  "REDACTED",
-				"command.sort._id":                                   nil,
-				fmt.Sprintf("command.sort.%s", HashFieldName("_id")): float64(-1),
+				"command.filter.$expr.$and.0.$eq.0":             HashName("foo"),
+				"command.filter.$expr.$and.0.$eq.1":             "REDACTED",
+				"command.filter.$expr.$and.1.$eq.0":             HashName("bar"),
+				"command.filter.$expr.$and.1.$eq.1":             "REDACTED",
+				"command.sort._id":                              nil,
+				fmt.Sprintf("command.sort.%s", HashName("_id")): float64(-1),
 				// We should also hash field names in the plan summary indiscriminately:
-				"planSummary": fmt.Sprintf("IXSCAN { %s: 1, %s: 1, %s: -1 }", HashFieldName("foo"), HashFieldName("bar"), HashFieldName("_id")),
+				"planSummary": fmt.Sprintf("IXSCAN { %s: 1, %s: 1, %s: -1 }", HashName("foo"), HashName("bar"), HashName("_id")),
 			},
 		},
 		{
@@ -218,18 +218,18 @@ func AnonymizerTestParams() []RedactTestCase {
 			InputFile: "complex_aggregation.json",
 			Options:   setOptionsRedactedStringsWithEagerRedaction,
 			ExpectedPaths: map[string]interface{}{
-				"command.pipeline.0.$match.$expr.$and.0.$ne.0":                                                       HashFieldName("status"),
-				"command.pipeline.0.$match.$expr.$and.0.$ne.1":                                                       "REDACTED",
-				"command.pipeline.0.$match.$expr.$and.1.$lt.1.$date":                                                 "1970-01-01T00:00:00.000Z",
-				"command.pipeline.0.$match.$expr.$and.1.$lt.0":                                                       HashFieldName("createdAt"),
-				fmt.Sprintf("command.pipeline.1.$lookup.pipeline.0.$match.%s.$oid", HashFieldName("organizationId")): "000000000000000000000000",
+				"command.pipeline.0.$match.$expr.$and.0.$ne.0":                                                  HashName("status"),
+				"command.pipeline.0.$match.$expr.$and.0.$ne.1":                                                  "REDACTED",
+				"command.pipeline.0.$match.$expr.$and.1.$lt.1.$date":                                            "1970-01-01T00:00:00.000Z",
+				"command.pipeline.0.$match.$expr.$and.1.$lt.0":                                                  HashName("createdAt"),
+				fmt.Sprintf("command.pipeline.1.$lookup.pipeline.0.$match.%s.$oid", HashName("organizationId")): "000000000000000000000000",
 				// We have to hash field names in the pipeline stages too now:
-				fmt.Sprintf("command.pipeline.1.$lookup.pipeline.1.$project.%s", HashFieldName("_id")):       float64(0),
-				fmt.Sprintf("command.pipeline.1.$lookup.pipeline.1.$project.%s", HashFieldName("name")):      float64(1),
-				fmt.Sprintf("command.pipeline.1.$lookup.pipeline.1.$project.%s", HashFieldName("createdAt")): float64(1),
-				fmt.Sprintf("command.pipeline.2.$project.%s.$cond.if.$eq.1", HashFieldName("numericStatus")): "REDACTED",
-				fmt.Sprintf("command.pipeline.2.$project.%s.$cond.then", HashFieldName("numericStatus")):     float64(-1),
-				fmt.Sprintf("command.pipeline.2.$project.%s.$cond.else", HashFieldName("numericStatus")):     float64(1),
+				fmt.Sprintf("command.pipeline.1.$lookup.pipeline.1.$project.%s", HashName("_id")):       float64(0),
+				fmt.Sprintf("command.pipeline.1.$lookup.pipeline.1.$project.%s", HashName("name")):      float64(1),
+				fmt.Sprintf("command.pipeline.1.$lookup.pipeline.1.$project.%s", HashName("createdAt")): float64(1),
+				fmt.Sprintf("command.pipeline.2.$project.%s.$cond.if.$eq.1", HashName("numericStatus")): "REDACTED",
+				fmt.Sprintf("command.pipeline.2.$project.%s.$cond.then", HashName("numericStatus")):     float64(-1),
+				fmt.Sprintf("command.pipeline.2.$project.%s.$cond.else", HashName("numericStatus")):     float64(1),
 			},
 		},
 		{
@@ -256,9 +256,9 @@ func AnonymizerTestParams() []RedactTestCase {
 			InputFile: "aggregation_stages_edge_cases.json",
 			Options:   setOptionsRedactedStringsWithEagerRedaction,
 			ExpectedPaths: map[string]interface{}{
-				"command.pipeline.0.$bucket.groupBy": HashFieldName("$year_born"),
-				"command.pipeline.1.$count":          HashFieldName("totalArtists"),
-				"command.pipeline.2.$densify.field":  HashFieldName("timestamp"),
+				"command.pipeline.0.$bucket.groupBy": HashName("$year_born"),
+				"command.pipeline.1.$count":          HashName("totalArtists"),
+				"command.pipeline.2.$densify.field":  HashName("timestamp"),
 			},
 		},
 		{
@@ -300,23 +300,23 @@ func AnonymizerTestParams() []RedactTestCase {
 			InputFile: "search_with_compound_operators.json",
 			Options:   setOptionsRedactedStringsWithEagerRedaction,
 			ExpectedPaths: map[string]interface{}{
-				"command.pipeline.0.$search.compound.should.0.text.path":                                                              HashFieldName("type"),
+				"command.pipeline.0.$search.compound.should.0.text.path":                                                              HashName("type"),
 				"command.pipeline.0.$search.compound.should.0.text.query":                                                             "REDACTED",
-				"command.pipeline.0.$search.compound.should.1.compound.must.0.text.path":                                              HashFieldName("category"),
+				"command.pipeline.0.$search.compound.should.1.compound.must.0.text.path":                                              HashName("category"),
 				"command.pipeline.0.$search.compound.should.1.compound.must.0.text.query":                                             "REDACTED",
 				"command.pipeline.0.$search.compound.should.1.compound.must.1.equals.value":                                           true,
-				"command.pipeline.0.$search.compound.should.1.compound.must.1.equals.path":                                            HashFieldName("in_stock"),
+				"command.pipeline.0.$search.compound.should.1.compound.must.1.equals.path":                                            HashName("in_stock"),
 				"command.pipeline.0.$search.compound.minimumShouldMatch":                                                              float64(1),
-				"command.pipeline.0.$search.compound.should.1.compound.must.2.embeddedDocument.path":                                  HashFieldName("items"),
+				"command.pipeline.0.$search.compound.should.1.compound.must.2.embeddedDocument.path":                                  HashName("items"),
 				"command.pipeline.0.$search.compound.should.1.compound.must.2.embeddedDocument.operator.compound.must.0.text.query":   "REDACTED",
-				"command.pipeline.0.$search.compound.should.1.compound.must.2.embeddedDocument.operator.compound.must.0.text.path":    HashFieldName("items.tags"),
+				"command.pipeline.0.$search.compound.should.1.compound.must.2.embeddedDocument.operator.compound.must.0.text.path":    HashName("items.tags"),
 				"command.pipeline.0.$search.compound.should.1.compound.must.2.embeddedDocument.operator.compound.should.0.text.query": "REDACTED",
-				"command.pipeline.0.$search.compound.should.1.compound.must.2.embeddedDocument.operator.compound.should.0.text.path":  HashFieldName("items.name"),
+				"command.pipeline.0.$search.compound.should.1.compound.must.2.embeddedDocument.operator.compound.should.0.text.path":  HashName("items.name"),
 				"command.pipeline.0.$search.compound.should.1.compound.must.2.embeddedDocument.score.embedded.aggregate":              "mean",
-				"command.pipeline.0.$search.compound.should.2.exists.path":                                                            HashFieldName("quantities.lemons"),
+				"command.pipeline.0.$search.compound.should.2.exists.path":                                                            HashName("quantities.lemons"),
 				"command.pipeline.0.$search.compound.should.3.geoShape.relation":                                                      "disjoint",
 				"command.pipeline.0.$search.compound.should.3.geoShape.geometry.type":                                                 "Polygon",
-				"command.pipeline.0.$search.compound.should.3.geoShape.path":                                                          HashFieldName("address.location"),
+				"command.pipeline.0.$search.compound.should.3.geoShape.path":                                                          HashName("address.location"),
 			},
 		},
 		{
@@ -337,8 +337,8 @@ func AnonymizerTestParams() []RedactTestCase {
 			InputFile: "search_meta_facets.json",
 			Options:   setOptionsRedactedStringsWithEagerRedaction,
 			ExpectedPaths: map[string]interface{}{
-				fmt.Sprintf("command.pipeline.0.$searchMeta.facet.facets.%s.type", HashFieldName("yearFacet")): "number",
-				fmt.Sprintf("command.pipeline.0.$searchMeta.facet.facets.%s.path", HashFieldName("yearFacet")): "year",
+				fmt.Sprintf("command.pipeline.0.$searchMeta.facet.facets.%s.type", HashName("yearFacet")): "number",
+				fmt.Sprintf("command.pipeline.0.$searchMeta.facet.facets.%s.path", HashName("yearFacet")): "year",
 			},
 		},
 		{
@@ -372,8 +372,8 @@ func AnonymizerTestParams() []RedactTestCase {
 			InputFile: "find_with_binary_data.json",
 			Options:   setOptionsRedactedStringsWithEagerRedaction,
 			ExpectedPaths: map[string]interface{}{
-				fmt.Sprintf("command.filter.%s.$binary.subType", HashFieldName("uuid")): "04",
-				fmt.Sprintf("command.filter.%s.$binary.base64", HashFieldName("uuid")):  "REDACTED",
+				fmt.Sprintf("command.filter.%s.$binary.subType", HashName("uuid")): "04",
+				fmt.Sprintf("command.filter.%s.$binary.base64", HashName("uuid")):  "REDACTED",
 				"planningTimeMicros": float64(43226),
 				"keysExamined":       float64(1),
 				"docsExamined":       float64(1),
@@ -392,6 +392,44 @@ func AnonymizerTestParams() []RedactTestCase {
 				"command.filter.$or.3.username": "redacted@redacted.com",
 			},
 		},
+		{
+			Name:      "Simple find with namespace redaction",
+			InputFile: "simple_find.json",
+			Options:   setOptionsRedactedStringsAndNamespaces,
+			ExpectedPaths: map[string]interface{}{
+				"command.filter.foo": "REDACTED",
+				"command.filter.bar": "REDACTED",
+				"nreturned":          float64(1),
+				"ns":                 HashName("my_db.my_coll"),
+			},
+		},
+		{
+			Name:      "Simple aggregation with namespace redaction",
+			InputFile: "simple_aggregation.json",
+			Options:   setOptionsRedactedStringsAndNamespaces,
+			ExpectedPaths: map[string]interface{}{
+				"ns":                               HashName("my_db.my_coll"),
+				"command.$db":                      HashName("my_db"),
+				"command.aggregate":                HashName("my_coll"),
+				"command.pipeline.0.$match.status": "REDACTED",
+				"command.pipeline.0.$match.createdAt.$lt.$date": "1970-01-01T00:00:00.000Z",
+			},
+		},
+		{
+			Name:      "Complex aggregation",
+			InputFile: "complex_aggregation.json",
+			Options:   setOptionsRedactedStringsAndNamespaces,
+			ExpectedPaths: map[string]interface{}{
+				"command.$db":       HashName("my_db"),
+				"command.aggregate": HashName("my_coll"),
+				"ns":                HashName("my_db.my_coll"),
+				"command.pipeline.0.$match.$expr.$and.0.$ne.1":                     "REDACTED",
+				"command.pipeline.0.$match.$expr.$and.1.$lt.1.$date":               "1970-01-01T00:00:00.000Z",
+				"command.pipeline.1.$lookup.pipeline.0.$match.organizationId.$oid": "000000000000000000000000",
+				"command.pipeline.1.$lookup.from":                                  HashName("another_coll"),
+				"command.pipeline.2.$project.numericStatus.$cond.if.$eq.1":         "REDACTED",
+			},
+		},
 	}
 }
 
@@ -401,6 +439,16 @@ func setOptionsRedactedStrings() {
 	SetRedactBooleans(false)
 	SetRedactIPs(false)
 	SetEagerRedactionPaths([]string{})
+	SetRedactNamespaces(false)
+}
+
+func setOptionsRedactedStringsAndNamespaces() {
+	SetRedactedString("REDACTED")
+	SetRedactNumbers(false)
+	SetRedactBooleans(false)
+	SetRedactIPs(false)
+	SetEagerRedactionPaths([]string{})
+	SetRedactNamespaces(true)
 }
 
 func setOptionsRedactedStringsWithEagerRedaction() {
@@ -411,6 +459,7 @@ func setOptionsRedactedStringsWithEagerRedaction() {
 	SetEagerRedactionPaths([]string{
 		"my_db.my_coll",
 	})
+	SetRedactNamespaces(false)
 }
 
 func setOptionsRedactedAllWithOverride() {
@@ -419,6 +468,7 @@ func setOptionsRedactedAllWithOverride() {
 	SetRedactBooleans(true)
 	SetRedactIPs(true)
 	SetEagerRedactionPaths([]string{})
+	SetRedactNamespaces(false)
 }
 
 func setOptionsRedactedAll() {
@@ -427,6 +477,7 @@ func setOptionsRedactedAll() {
 	SetRedactBooleans(true)
 	SetRedactIPs(true)
 	SetEagerRedactionPaths([]string{})
+	SetRedactNamespaces(false)
 }
 
 func setOptionsRedactedIPs() {
@@ -435,4 +486,5 @@ func setOptionsRedactedIPs() {
 	SetRedactBooleans(false)
 	SetRedactIPs(true)
 	SetEagerRedactionPaths([]string{})
+	SetRedactNamespaces(false)
 }

--- a/src/anonymizer_test_params.go
+++ b/src/anonymizer_test_params.go
@@ -416,7 +416,7 @@ func AnonymizerTestParams() []RedactTestCase {
 			},
 		},
 		{
-			Name:      "Complex aggregation",
+			Name:      "Lookup aggregation with namespace redaction",
 			InputFile: "complex_aggregation.json",
 			Options:   setOptionsRedactedStringsAndNamespaces,
 			ExpectedPaths: map[string]interface{}{
@@ -428,6 +428,22 @@ func AnonymizerTestParams() []RedactTestCase {
 				"command.pipeline.1.$lookup.pipeline.0.$match.organizationId.$oid": "000000000000000000000000",
 				"command.pipeline.1.$lookup.from":                                  HashName("another_coll"),
 				"command.pipeline.2.$project.numericStatus.$cond.if.$eq.1":         "REDACTED",
+			},
+		},
+		{
+			Name:      "Find and modify with namespace redaction",
+			InputFile: "find_and_modify.json",
+			Options:   setOptionsRedactedStringsAndNamespaces,
+			ExpectedPaths: map[string]interface{}{
+				"command.$db":                           HashName("my_db"),
+				"command.findAndModify":                 HashName("my_coll"),
+				"ns":                                    HashName("my_db.my_coll"),
+				"command.update.$set.updatedAt.$date":   "1970-01-01T00:00:00.000Z",
+				"command.update.$set.updatedBy.$oid":    "000000000000000000000000",
+				"command.update.$set.status":            "REDACTED",
+				"command.update.$addToSet.tags.$each.0": "REDACTED",
+				"command.update.$addToSet.tags.$each.1": "REDACTED",
+				"command.update.$addToSet.tags.$each.2": "REDACTED",
 			},
 		},
 	}

--- a/src/anonymizer_test_params.go
+++ b/src/anonymizer_test_params.go
@@ -395,9 +395,11 @@ func AnonymizerTestParams() []RedactTestCase {
 		{
 			Name:      "Error query",
 			InputFile: "error-query.json",
-			Options:   setOptionsRedactedStrings,
+			Options:   setOptionsRedactedStringsAndNamespaces,
 			ExpectedPaths: map[string]interface{}{
 				"cmd.pipeline.0.$match.foo": "REDACTED",
+				"cmd.aggregate":             HashName("mycollection"),
+				"cmd.$db":                   HashName("mydb"),
 			},
 		},
 		{

--- a/src/helpers.go
+++ b/src/helpers.go
@@ -55,8 +55,8 @@ func ParsePlanSummary(planSummary string) []string {
 	return fields
 }
 
-// HashFieldName returns a consistent hash for a field name.
-func HashFieldName(field string) string {
+// HashName returns a consistent hash for a field name.
+func HashName(field string) string {
 	trimmed := strings.TrimLeft(field, "$")
 	parts := strings.Split(trimmed, ".")
 	hashedParts := make([]string, len(parts))

--- a/src/helpers_test.go
+++ b/src/helpers_test.go
@@ -67,7 +67,7 @@ func TestParsePlanSummary(t *testing.T) {
 	}
 }
 
-func TestHashFieldName(t *testing.T) {
+func TestHashName(t *testing.T) {
 	originalRedactedString := redactedString
 	redactedString = "REDACTED"
 	defer func() { redactedString = originalRedactedString }()
@@ -113,14 +113,14 @@ func TestHashFieldName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			RedactedFieldMapping = make(map[string]string)
 
-			actualHash := HashFieldName(tc.field)
+			actualHash := HashName(tc.field)
 
 			if actualHash != tc.expectedHash {
-				t.Errorf("HashFieldName() hash = %q, want %q", actualHash, tc.expectedHash)
+				t.Errorf("HashName() hash = %q, want %q", actualHash, tc.expectedHash)
 			}
 
 			if !reflect.DeepEqual(RedactedFieldMapping, tc.expectedMap) {
-				t.Errorf("HashFieldName() map = %v, want %v", RedactedFieldMapping, tc.expectedMap)
+				t.Errorf("HashName() map = %v, want %v", RedactedFieldMapping, tc.expectedMap)
 			}
 		})
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -30,6 +30,7 @@ func main() {
 		atlasLogStartDate   int
 		atlasLogEndDate     int
 		encryptionKeyFile   string
+		redactNamespaces    bool
 	)
 	// Flag for the "decrypt" command
 	var (
@@ -111,6 +112,7 @@ You can provide input either as a file (as the first argument) or by piping logs
 			SetEagerRedactionPaths(eagerRedactionPaths)
 			SetAtlasLogStartDate(atlasLogStartDate)
 			SetAtlasLogEndDate(atlasLogEndDate)
+			SetRedactNamespaces(redactNamespaces)
 
 			var outWriter *os.File
 			var err error
@@ -338,6 +340,7 @@ addition to their values. The structure is either a namespace; e.g., 'dbName.col
 Extract the last 7 days if not provided`)
 	redactCmd.Flags().IntVarP(&atlasLogEndDate, "atlasLogEndDate", "e", 0, `Atlas log end date in epoch seconds, if reading logs from an Atlas cluster.
 Extract the last 7 days if not provided`)
+	redactCmd.Flags().BoolVarP(&redactNamespaces, "redactNamespaces", "w", false, "Redact database and collection names")
 
 	// Bind flags to the "decrypt" subcommand
 	decryptCmd.Flags().StringVarP(&decryptionKeyFile, "decryptionKeyFile", "", "./anonymongo.enc.key", "Path to the AES256 encryption key file")

--- a/src/operators.go
+++ b/src/operators.go
@@ -13,6 +13,7 @@ const (
 	FieldName     OperatorType = iota
 	OperatorArray OperatorType = iota
 	OperatorMap   OperatorType = iota
+	Namespace     OperatorType = iota
 )
 
 var AggregationOperators = func() OrderedMap {
@@ -83,7 +84,7 @@ var AggregationOperators = func() OrderedMap {
 	geoNear.Set("spherical", Redactable)
 	m.Set("$geoNear", geoNear)
 	graphLookup := orderedmap.NewOrderedMap[string, any]()
-	graphLookup.Set("from", Exempt)
+	graphLookup.Set("from", Namespace)
 	graphLookup.Set("startWith", Redactable)
 	graphLookup.Set("connectFromField", FieldName)
 	graphLookup.Set("connectToField", FieldName)
@@ -112,7 +113,7 @@ var AggregationOperators = func() OrderedMap {
 	listSessions.Set("allUsers", Redactable)
 	m.Set("$listSessions", listSessions)
 	lookup := orderedmap.NewOrderedMap[string, any]()
-	lookup.Set("from", Exempt)
+	lookup.Set("from", Namespace)
 	lookup.Set("localField", Redactable)
 	lookup.Set("foreignField", Redactable)
 	lookup.Set("let", Redactable)
@@ -121,15 +122,15 @@ var AggregationOperators = func() OrderedMap {
 	m.Set("$lookup", lookup)
 	m.Set("$match", Redactable)
 	merge := orderedmap.NewOrderedMap[string, any]()
-	merge.Set("into", Exempt)
+	merge.Set("into", Namespace)
 	merge.Set("on", Redactable)
 	merge.Set("let", Redactable)
 	merge.Set("whenMatched", Exempt)
 	merge.Set("whenNotMatched", Exempt)
 	m.Set("$merge", merge)
 	out := orderedmap.NewOrderedMap[string, any]()
-	out.Set("db", Exempt)
-	out.Set("coll", Exempt)
+	out.Set("db", Namespace)
+	out.Set("coll", Namespace)
 	out.Set("timeseries", Exempt)
 	m.Set("$out", out)
 	m.Set("$planCacheStats", Exempt)
@@ -155,7 +156,7 @@ var AggregationOperators = func() OrderedMap {
 	m.Set("$sort", Redactable)
 	m.Set("$sortByCount", FieldName)
 	unionWith := orderedmap.NewOrderedMap[string, any]()
-	unionWith.Set("coll", Exempt)
+	unionWith.Set("coll", Namespace)
 	unionWith.Set("pipeline", Pipeline)
 	m.Set("$unionWith", unionWith)
 	m.Set("$unset", FieldName)

--- a/test_fixtures/find_and_modify.json
+++ b/test_fixtures/find_and_modify.json
@@ -1,0 +1,139 @@
+{
+  "t": {
+    "$date": "2025-06-27T22:59:51.576+00:00"
+  },
+  "s": "I",
+  "c": "COMMAND",
+  "id": 51803,
+  "ctx": "conn65301",
+  "msg": "Slow query",
+  "attr": {
+    "type": "command",
+    "ns": "my_db.my_coll",
+    "command": {
+      "findAndModify": "my_coll",
+      "query": {
+        "_id": {
+          "$oid": "685f225e4b79aa83dd30d689"
+        }
+      },
+      "remove": false,
+      "new": true,
+      "upsert": false,
+      "update": {
+        "$set": {
+          "updatedAt": {
+            "$date": "2025-06-27T22:59:51.232Z"
+          },
+          "updatedBy": {
+            "$oid": "600c1969d8d0af8ebcfa6010"
+          },
+          "status": "ACTIVE"
+        },
+        "$addToSet": {
+          "tags": {
+            "$each": [
+              "tag1",
+              "tag2",
+              "tag3"
+            ]
+          }
+        }
+      },
+      "lsid": {
+        "id": {
+          "$uuid": "8892a435-43af-460a-b823-56621db1c3b7"
+        }
+      },
+      "txnNumber": 1484,
+      "$clusterTime": {
+        "clusterTime": {
+          "$timestamp": {
+            "t": 1751065191,
+            "i": 13
+          }
+        },
+        "signature": {
+          "hash": {
+            "$binary": {
+              "base64": "icSvXujnGXb9wDUXWEprKwaVwW0=",
+              "subType": "0"
+            }
+          },
+          "keyId": 7458838118326600000
+        }
+      },
+      "$db": "my_db"
+    },
+    "planSummary": "IDHACK",
+    "totalOplogSlotDurationMicros": 634,
+    "keysExamined": 1,
+    "docsExamined": 1,
+    "nMatched": 1,
+    "nModified": 1,
+    "nUpserted": 0,
+    "keysInserted": 11,
+    "keysDeleted": 11,
+    "numYields": 0,
+    "reslen": 8005,
+    "locks": {
+      "ParallelBatchWriterMode": {
+        "acquireCount": {
+          "r": 3
+        }
+      },
+      "FeatureCompatibilityVersion": {
+        "acquireCount": {
+          "w": 3
+        }
+      },
+      "ReplicationStateTransition": {
+        "acquireCount": {
+          "w": 4
+        }
+      },
+      "Global": {
+        "acquireCount": {
+          "w": 3
+        }
+      },
+      "Database": {
+        "acquireCount": {
+          "w": 2
+        }
+      },
+      "Collection": {
+        "acquireCount": {
+          "w": 3
+        }
+      },
+      "Mutex": {
+        "acquireCount": {
+          "r": 3
+        }
+      }
+    },
+    "flowControl": {
+      "acquireCount": 1
+    },
+    "readConcern": {
+      "level": "local",
+      "provenance": "implicitDefault"
+    },
+    "writeConcern": {
+      "w": "majority",
+      "wtimeout": 0,
+      "provenance": "implicitDefault"
+    },
+    "waitForWriteConcernDurationMillis": 341,
+    "storage": {
+      "data": {
+        "bytesRead": 9760,
+        "timeReadingMicros": 12
+      }
+    },
+    "remote": "63.34.138.217:13415",
+    "protocol": "op_msg",
+    "durationMillis": 342
+  }
+}


### PR DESCRIPTION
Closes #42  